### PR TITLE
hotfix github pages routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import preset from 'jss-preset-default';
 import { useLayoutEffect } from 'react';
 import { JssProvider, ThemeProvider } from 'react-jss';
 import { useDispatch, useSelector } from 'react-redux';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { HashRouter as Router, Route, Switch } from 'react-router-dom';
 import reset from 'reset-jss';
 
 import { baseurl } from '../siteMeta';


### PR DESCRIPTION
Direct links to position pages `/:id` doesn't work on github pages, switching to hash router.